### PR TITLE
Force the nms build process.

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -3,6 +3,6 @@ cd ./utils/
 
 CUDA_PATH=/usr/local/cuda/
 
-python build.py build_ext --inplace
+python build.py build_ext --inplace --force
 
 cd ..


### PR DESCRIPTION
This is a fix for #131.
I faced a similar error when I tried to build the `nms` extension. This solution worked for me. Hence this PR.